### PR TITLE
Run xref-after-jump-hook after navigating to a reference

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1012,7 +1012,8 @@
           :ret-action (lambda (&rest _)
                         (interactive)
                         (lsp-treemacs--open-file-in-mru filename)
-                        (goto-char point)))))
+                        (goto-char point)
+                        (run-hooks 'xref-after-jump-hook)))))
 
 (defun lsp-treemacs-initialize ()
   (unless (derived-mode-p 'treemacs-mode)


### PR DESCRIPTION
* lsp-treemacs.el (lsp-treemacs--make-ref-item): Run
xref-after-jump-hook, which by default will recenter the buffer and
briefly pulse the reference to quickly locate it.