### PR TITLE
Fix `cond` default case

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -949,7 +949,7 @@
                                      `((:label ,(propertize "Loading..." 'face 'shadow)
                                                :icon-literal " "
                                                :key "Loading...")))
-                     ((t children))))
+                     (t children)))
   :ret-action #'lsp-treemacs-perform-ret-action
   :render-action
   (-let [(&plist :children :label :key :children-async) item]


### PR DESCRIPTION
The Elisp interpreter assumed `t` was a function and not a symbol.

Some lsp-treemacs commands were triggering the debugger with the following error:

> Debugger entered--Lisp error: (void-function t)