### PR TITLE
Mode line improvements

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -150,7 +150,7 @@
                 (goto-char (point-min))
                 (forward-line (lsp-diagnostic-line diag))
                 (lsp-execute-code-action-by-kind "quickfix")))))
-      (user-error "Not no a diagnostic"))))
+      (user-error "Not on a diagnostic"))))
 
 (defun lsp-treemacs-cycle-severity ()
   "Cycle through the severity levels shown in the errors list"

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1173,6 +1173,8 @@
 
 ;;;###autoload
 (defun lsp-treemacs-references (arg)
+  "Show the references for the symbol at point.
+With a prefix argument, expand the tree of references automatically."
   (interactive "P")
   (lsp-treemacs--do-search "textDocument/references"
                            `(:context (:includeDeclaration t) ,@(lsp--text-document-position-params))
@@ -1181,6 +1183,8 @@
 
 ;;;###autoload
 (defun lsp-treemacs-implementations (arg)
+  "Show the implementations for the symbol at point.
+With a prefix argument, expand the tree of implementations automatically."
   (interactive "P")
   (lsp-treemacs--do-search "textDocument/implementation"
                            (lsp--text-document-position-params)
@@ -1219,6 +1223,8 @@
 
 ;;;###autoload
 (defun lsp-treemacs-call-hierarchy (outgoing)
+  "Show the incoming call hierarchy for the symbol at point.
+With a prefix argument, show the outgoing call hierarchy."
   (interactive "P")
   (unless (lsp--find-workspaces-for "textDocument/prepareCallHierarchy")
     (user-error "Call hierarchy not supported by the current servers: %s"

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -331,9 +331,6 @@
   :keymap lsp-treemacs-error-list-mode-map
   :group 'lsp-treeemacs)
 
-(define-derived-mode lsp-treemacs-errors-mode treemacs-mode "LSP Errors View"
-  "A major mode for displaying LSP Errors.")
-
 ;;;###autoload
 (defun lsp-treemacs-errors-list ()
   "Display error list."
@@ -348,7 +345,7 @@
       (select-window window)
       (set-window-dedicated-p window t)
       (treemacs-initialize)
-      (lsp-treemacs-errors-mode)
+      (lsp-treemacs--set-mode-line-format buffer " LSP Errors View ")
       (lsp-treemacs-error-list-mode 1)
 
       (setq-local treemacs-default-visit-action 'treemacs-RET-action)
@@ -780,9 +777,6 @@
           (lsp--info "Refresh completed")))
     (error)))
 
-(define-derived-mode lsp-treemacs-java-deps-mode treemacs-mode "Java Dependencies"
-  "A major mode for displaying Java Dependencies.")
-
 ;;;###autoload
 (defun lsp-treemacs-java-deps-list ()
   "Display error list."
@@ -796,7 +790,7 @@
       (select-window window)
       (set-window-dedicated-p window t)
       (treemacs-initialize)
-      (lsp-treemacs-java-deps-mode)
+      (lsp-treemacs--set-mode-line-format buffer " Java Dependencies ")
       (lsp-treemacs-deps-list-mode t)
 
       (setq-local treemacs-space-between-root-nodes nil)

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -556,7 +556,7 @@
    (lsp-treemacs--symbols->tree
     lsp-treemacs--symbols
     nil)
-   "LSP Symbols"
+   " LSP Symbols "
    (and lsp-treemacs--symbols (> 30 (length lsp-treemacs--symbols)))
    "*LSP Symbols List*" ))
 


### PR DESCRIPTION
With some standard mode lines, lsp-treemacs always shows "Treemacs" in the mode line, making panes difficult to distinguish.

This PR solves the problem by setting either of these two buffer local variables:

- `mode-name`. For Doom/Spacemacs/Moody, Treemacs builds a custom `mode-line-format` that displays the mode name along with other info in a propertized way.
- `mode-line-format`. In standard mode lines, Treemacs modifies the `mode-line-format` to show " Treemacs ", so from lsp-treemacs we'll do the same but show a descriptive pane title instead.

I think this PR supersedes https://github.com/emacs-lsp/lsp-treemacs/pull/10, so I've removed the major modes that that PR created.