### PR TITLE
Append existing experimental capabilities

### DIFF
--- a/lsp-metals-treeview.el
+++ b/lsp-metals-treeview.el
@@ -813,13 +813,9 @@ METALS-CLIENT."
 be sent during initialisation. Add to our custom capabilities so
 that this will be sent during initial connection."
   (interactive)
-  (let ((custom-capabilities
-         (append (lsp--client-custom-capabilities metals-client)
-                 `((experimental
-                    (treeViewProvider . ,(if enable?
-                                             t
-                                           :json-false)))))))
-    (setf (lsp--client-custom-capabilities metals-client) custom-capabilities)))
+  (let* ((custom-capabilities (lsp--client-custom-capabilities metals-client))
+          (experimental (cl-find-if (lambda (e) (eq (car e) 'experimental)) custom-capabilities)))
+    (nconc (cdr experimental) `((treeViewProvider . ,(if enable? t :json-false))))))
 
 (defun lsp-metals-treeview (&optional workspace)
   "Display the Metals treeview window for the WORKSPACE (optional).  If


### PR DESCRIPTION
I just assume that metals already defines experimental capabilities (can't see how I can do it without such assumption and won't make it ugly).

Should be merged after https://github.com/emacs-lsp/lsp-mode/pull/1346