### PR TITLE
Auto select-window on find references/implementations

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1196,8 +1196,9 @@ depending on if a custom mode line is detected."
      :mode 'detached
      :cancel-token :treemacs-lookup)
 
-    (select-window window)
-    (set-window-dedicated-p window t)
+    (when expand?
+      (select-window window)
+      (set-window-dedicated-p window t))
 
     (with-current-buffer search-buffer
       (lsp-treemacs-initialize)
@@ -1208,7 +1209,7 @@ depending on if a custom mode line is detected."
 ;;;###autoload
 (defun lsp-treemacs-references (arg)
   "Show the references for the symbol at point.
-With a prefix argument, expand the tree of references automatically."
+With a prefix argument, select the new window and expand the tree of references automatically."
   (interactive "P")
   (lsp-treemacs--do-search "textDocument/references"
                            `(:context (:includeDeclaration t) ,@(lsp--text-document-position-params))
@@ -1218,7 +1219,7 @@ With a prefix argument, expand the tree of references automatically."
 ;;;###autoload
 (defun lsp-treemacs-implementations (arg)
   "Show the implementations for the symbol at point.
-With a prefix argument, expand the tree of implementations automatically."
+With a prefix argument, select the new window expand the tree of implementations automatically."
   (interactive "P")
   (lsp-treemacs--do-search "textDocument/implementation"
                            (lsp--text-document-position-params)

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1148,7 +1148,7 @@
                                    (interactive)
                                    (lsp-treemacs--open-file-in-mru path)))))))
 
-(defun lsp-treemacs-render (tree title expand? &optional buffer-name right-click-actions)
+(defun lsp-treemacs-render (tree title prefix-args &optional buffer-name right-click-actions)
   (let ((search-buffer (get-buffer-create (or buffer-name "*LSP Lookup*"))))
     (with-current-buffer search-buffer
       (lsp-treemacs-initialize)
@@ -1159,7 +1159,8 @@
       (setq-local face-remapping-alist '((button . default)))
       (lsp-treemacs--set-mode-line-format search-buffer title)
       (lsp-treemacs-generic-refresh)
-      (when expand? (lsp-treemacs--expand 'LSP-Generic))
+      (when (equal prefix-args '(4))
+        (lsp-treemacs--expand 'LSP-Generic))
       (current-buffer))))
 
 (defalias 'lsp-treemacs--show-references 'lsp-treemacs-render)
@@ -1178,7 +1179,7 @@ depending on if a custom mode line is detected."
           (t
            (setq mode-line-format title)))))
 
-(defun lsp-treemacs--do-search (method params title expand?)
+(defun lsp-treemacs--do-search (method params title prefix-args)
   (let ((search-buffer (get-buffer-create "*LSP Lookup*"))
         (window (display-buffer-in-side-window (get-buffer-create "*LSP Lookup*")
                                                '((side . bottom)))))
@@ -1191,12 +1192,13 @@ depending on if a custom mode line is detected."
         (let ((lsp-file-truename-cache (ht)))
           (lsp-treemacs-render (lsp-treemacs--handle-references refs)
                                (format title (length refs))
-                               expand?)))
+                               prefix-args)))
        (lsp--info "Refresh completed!"))
      :mode 'detached
      :cancel-token :treemacs-lookup)
 
-    (when expand?
+    (when (or (null prefix-args)
+              (equal prefix-args '(4)))
       (select-window window)
       (set-window-dedicated-p window t))
 

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1179,9 +1179,9 @@ depending on if a custom mode line is detected."
            (setq mode-line-format title)))))
 
 (defun lsp-treemacs--do-search (method params title expand?)
-  (let ((search-buffer (get-buffer-create "*LSP Lookup*")))
-    (display-buffer-in-side-window search-buffer
-                                   '((side . bottom)))
+  (let ((search-buffer (get-buffer-create "*LSP Lookup*"))
+        (window (display-buffer-in-side-window (get-buffer-create "*LSP Lookup*")
+                                               '((side . bottom)))))
     (lsp-request-async
      method
      params
@@ -1195,6 +1195,9 @@ depending on if a custom mode line is detected."
        (lsp--info "Refresh completed!"))
      :mode 'detached
      :cancel-token :treemacs-lookup)
+
+    (select-window window)
+    (set-window-dedicated-p window t)
 
     (with-current-buffer search-buffer
       (lsp-treemacs-initialize)

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1148,7 +1148,7 @@
                                    (interactive)
                                    (lsp-treemacs--open-file-in-mru path)))))))
 
-(defun lsp-treemacs-render (tree title prefix-args &optional buffer-name right-click-actions)
+(defun lsp-treemacs-render (tree title expand? &optional buffer-name right-click-actions)
   (let ((search-buffer (get-buffer-create (or buffer-name "*LSP Lookup*"))))
     (with-current-buffer search-buffer
       (lsp-treemacs-initialize)
@@ -1159,7 +1159,7 @@
       (setq-local face-remapping-alist '((button . default)))
       (lsp-treemacs--set-mode-line-format search-buffer title)
       (lsp-treemacs-generic-refresh)
-      (when (equal prefix-args '(4))
+      (when (equal expand? '(4))
         (lsp-treemacs--expand 'LSP-Generic))
       (current-buffer))))
 
@@ -1197,8 +1197,7 @@ depending on if a custom mode line is detected."
      :mode 'detached
      :cancel-token :treemacs-lookup)
 
-    (when (or (null prefix-args)
-              (equal prefix-args '(4)))
+    (unless (zerop prefix-args)
       (select-window window)
       (set-window-dedicated-p window t))
 


### PR DESCRIPTION
Currently when you use `lsp-treemacs-errors-list`, automatically jumps to the new buffer showing the errors, but `lsp-treemacs-references` don't do that.

This PR fixes `lsp-treemacs-references` and `lsp-treemacs-implementations` to jump like `lsp-treemacs-errors-list`