### PR TITLE
Added depth argument to lsp-treemacs--expand

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -612,10 +612,10 @@
     (add-to-list 'winum-ignored-buffers "*LSP Error List*")
     (add-to-list 'winum-ignored-buffers  lsp-treemacs-deps-buffer-name)))
 
-(defun lsp-treemacs--expand (root-key)
+(defun lsp-treemacs--expand (root-key depth)
   (-when-let (root (treemacs-dom-node->position (treemacs-find-in-dom root-key)))
     (treemacs-save-position
-     (lsp-treemacs--expand-recursively root))))
+     (lsp-treemacs--expand-recursively root depth))))
 
 (defun lsp-treemacs--kill-symbols-buffer ()
   (and lsp-treemacs--symbols-timer (cancel-timer lsp-treemacs--symbols-timer)))
@@ -637,15 +637,16 @@
         (add-hook 'kill-buffer-hook 'lsp-treemacs--kill-symbols-buffer nil t)))
     (with-current-buffer original-buffer (lsp-treemacs--update))))
 
-(defun lsp-treemacs--expand-recursively (root)
-  (save-excursion
-    (-map
-     (lambda (btn)
-       (unless (treemacs-is-node-expanded? btn)
-         (goto-char (marker-position btn))
-         (funcall (alist-get (treemacs-button-get btn :state) treemacs-TAB-actions-config)))
-       (lsp-treemacs--expand-recursively btn))
-     (treemacs--get-children-of root))))
+(defun lsp-treemacs--expand-recursively (root depth)
+  (when (if (booleanp depth) depth (not (zerop depth)))
+    (save-excursion
+      (-map
+       (lambda (btn)
+         (unless (treemacs-is-node-expanded? btn)
+           (goto-char (marker-position btn))
+           (funcall (alist-get (treemacs-button-get btn :state) treemacs-TAB-actions-config)))
+         (lsp-treemacs--expand-recursively btn (if (booleanp depth) depth (1- depth))))
+       (treemacs--get-children-of root)))))
 
 
 (defmacro lsp-treemacs-deps-with-jdtls (&rest body)
@@ -1159,7 +1160,7 @@
            ,@body)
        (treemacs-pulse-on-failure "No node at point"))))
 
-(defun lsp-treemacs-render (tree title expand? &optional buffer-name right-click-actions)
+(defun lsp-treemacs-render (tree title expand-depth &optional buffer-name right-click-actions)
   (let ((search-buffer (get-buffer-create (or buffer-name "*LSP Lookup*"))))
     (with-current-buffer search-buffer
       (lsp-treemacs-initialize)
@@ -1170,7 +1171,7 @@
       (setq-local face-remapping-alist '((button . default)))
       (lsp-treemacs--set-mode-line-format search-buffer title)
       (lsp-treemacs-generic-refresh)
-      (when expand? (lsp-treemacs--expand 'LSP-Generic))
+      (lsp-treemacs--expand 'LSP-Generic expand-depth)
       (current-buffer))))
 
 (defalias 'lsp-treemacs--show-references 'lsp-treemacs-render)


### PR DESCRIPTION
Replaced `expand?` with `expand-depth` in `lsp-treemacs-render` and added a depth argument to lsp-treemacs--expand to support https://github.com/emacs-lsp/dap-mode/issues/230.