### PR TITLE
Remove lsp-treemacs-current-theme-name

### DIFF
--- a/lsp-treemacs-themes.el
+++ b/lsp-treemacs-themes.el
@@ -31,10 +31,6 @@
   :type 'string
   :group 'lsp-treemacs)
 
-(defun lsp-treemacs-current-theme-name ()
-  "Return the current treemacs theme name."
-  (treemacs-theme->name lsp-treemacs-theme))
-
 (treemacs-modify-theme "Default"
   :icon-directory (f-join (f-dirname (or load-file-name buffer-file-name)) "icons/vscode")
   :config

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -384,7 +384,7 @@
 
 (defun lsp-treemacs-get-icon (icon-name)
   "Get the treemacs ICON using current theme."
-  (treemacs-get-icon-value icon-name nil (lsp-treemacs-current-theme-name)))
+  (treemacs-get-icon-value icon-name nil lsp-treemacs-theme))
 
 (defun lsp-treemacs-symbol-icon (kind)
   "Get icon for `kind'."


### PR DESCRIPTION
lsp-treemacs-theme is a string, not a theme, so avoid the accessor function.

I noticed this bug because of an invalid comparison when the LSP breadcrumb was being put together.