### PR TITLE
Include symbol name when detailed-outline is enabled

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -486,7 +486,8 @@ DocumentSymbols."
                         current))
            (seq-map
             (-lambda ((&DocumentSymbol :name :detail? :kind :selection-range (&Range :start start-range) :children? :deprecated?))
-              (let ((sig (or (and lsp-treemacs-detailed-outline detail?) name)))
+              (let ((sig (or (and lsp-treemacs-detailed-outline (concat name " " detail?))
+                             name)))
                 `(:label ,(if deprecated?
                               (propertize sig 'face 'lsp-face-semhl-deprecated)
                             sig)


### PR DESCRIPTION
After 1dbc202fe61b48c94ed872df80403456f51bf46c, when `lsp-treemacs-detailed-outline` is `t`, the name of the symbol is not included in the tree and only the detail is rendered. This is a small fix to include the name. Based on the spec, `detail` only includes additional information, so the name should always be rendered