### PR TITLE
Fix goto defintion

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -462,11 +462,9 @@ this hook will be run after having jumped to the target."
   :group 'lsp-treemacs
   :type '(list function))
 
-(defun lsp-treemacs-symbols-goto-symbol (node)
-  "Goto the symbol at NODE.
-NODE is the symbol node at point when called interactively."
-  (interactive (list (treemacs-node-at-point)))
-  (let ((loc (-> node
+(defun lsp-treemacs-symbols-goto-symbol (&rest _)
+  "Goto the symbol node at `point'."
+  (let ((loc (-> (treemacs-node-at-point)
                  (button-get :item)
                  (plist-get :location))))
     (pop-to-buffer lsp-treemacs--symbols-last-buffer)


### PR DESCRIPTION
Since `lsp-treemacs-perform-ret-action` no longer passes the node to
:ret-action, an error is thrown when pressing RET on a symbol.

Fix that by having `lsp-treemcas-symbols-goto-symbol` take `&rest` and to always
use the node at point.

Sorry, it seems I haven't tested my PR thoroughly enough...