### PR TITLE
Add lsp-treemacs-errors-position-params variable

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -48,12 +48,17 @@
   `((side . ,treemacs-position)
     (slot . 1)
     (window-width . ,treemacs-width))
-  "The params which will be used by `display-buffer-in-side-window'.")
+  "The params which will be used by `display-buffer-in-side-window' in `lsp-treemacs-java-deps-list'.")
 
 (defvar lsp-treemacs-symbols-position-params
   `((side . ,treemacs-position)
     (slot . 2)
-    (window-width . ,treemacs-width)))
+    (window-width . ,treemacs-width))
+  "The params which will be used by `display-buffer-in-side-window' in `lsp-treemacs-symbols'.")
+
+(defvar lsp-treemacs-errors-position-params
+  `((side . bottom))
+  "The params which will be used by `display-buffer-in-side-window' in `lsp-treemacs-errors-list'.")
 
 (defface lsp-treemacs-project-root-error
   '((t :inherit font-lock-keyword-face))
@@ -524,7 +529,7 @@ will be rendered an empty line between them."
 
 ;;;###autoload
 (defun lsp-treemacs-java-deps-list ()
-  "Display error list."
+  "Display java dependencies."
   (interactive)
   (-if-let (buffer (get-buffer lsp-treemacs-deps-buffer-name))
       (select-window
@@ -1241,10 +1246,10 @@ With prefix 2 show both."
   (interactive)
   (-if-let (buffer (get-buffer lsp-treemacs-errors-buffer-name))
       (progn
-        (select-window (display-buffer-in-side-window buffer '((side . bottom))))
+        (select-window (display-buffer-in-side-window buffer lsp-treemacs-errors-position-params))
         (lsp-treemacs-errors-list--refresh))
     (let* ((buffer (lsp-treemacs-errors-list--refresh))
-           (window (display-buffer-in-side-window buffer '((side . bottom)))))
+           (window (display-buffer-in-side-window buffer lsp-treemacs-errors-position-params)))
       (select-window window)
       (set-window-dedicated-p window t)
       (lsp-treemacs-error-list-mode 1)

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -48,17 +48,22 @@
   `((side . ,treemacs-position)
     (slot . 1)
     (window-width . ,treemacs-width))
-  "The params which will be used by `display-buffer-in-side-window' in `lsp-treemacs-java-deps-list'.")
+  "The params which will be used by
+  `display-buffer-in-side-window' in
+  `lsp-treemacs-java-deps-list'.")
 
 (defvar lsp-treemacs-symbols-position-params
   `((side . ,treemacs-position)
     (slot . 2)
     (window-width . ,treemacs-width))
-  "The params which will be used by `display-buffer-in-side-window' in `lsp-treemacs-symbols'.")
+  "The params which will be used by
+  `display-buffer-in-side-window' in `lsp-treemacs-symbols'.")
 
 (defvar lsp-treemacs-errors-position-params
   `((side . bottom))
-  "The params which will be used by `display-buffer-in-side-window' in `lsp-treemacs-errors-list'.")
+  "The params which will be used by
+  `display-buffer-in-side-window' in
+  `lsp-treemacs-errors-list'.")
 
 (defface lsp-treemacs-project-root-error
   '((t :inherit font-lock-keyword-face))


### PR DESCRIPTION
Use this to configure the window position for the`lsp-treemacs-errors-list`. See `display-buffer-in-side-window` for available options.git@github.com:ch1bo/lsp-treemacs.git

Related to #100 