### PR TITLE
Add option to show current project errors only

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1237,15 +1237,18 @@ With prefix 2 show both."
    folders))
 
 
-(defvar lsp-treemacs--current-project-root nil)
+(defvar lsp-treemacs--current-project-roots nil)
 
 (defun lsp-treemacs-errors-list--refresh ()
+  (message "->%s" lsp-treemacs--current-project-roots)
   (lsp-treemacs-render
-   (if (and lsp-treemacs--current-project-root
+   (if (and lsp-treemacs--current-project-roots
             lsp-treemacs-error-list-current-project-only)
        (->> (lsp-session)
             (lsp-session-folders)
-            (--filter (f-equal-p lsp-treemacs--current-project-root it))
+            (-filter (lambda (folder)
+                       (--any (f-equal-p it folder)
+                              lsp-treemacs--current-project-roots)))
             (lsp-treemacs--build-error-list))
      (->> (lsp-session)
           (lsp-session-folders)
@@ -1258,9 +1261,7 @@ With prefix 2 show both."
 ;;;###autoload
 (defun lsp-treemacs-errors-list ()
   (interactive)
-  (setq lsp-treemacs--current-project-root (-some-> (lsp-workspaces)
-                                                    cl-first
-                                                    (lsp--workspace-root)))
+  (setq lsp-treemacs--current-project-roots (-map #'lsp--workspace-root (lsp-workspaces)))
   (-if-let (buffer (get-buffer lsp-treemacs-errors-buffer-name))
       (progn
         (select-window (display-buffer-in-side-window buffer '((side . bottom))))

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1237,7 +1237,8 @@ With prefix 2 show both."
 
 (defun lsp-treemacs-errors-list--refresh ()
   (lsp-treemacs-render
-   (if lsp-treemacs-error-list-current-project-only
+   (if (and lsp-treemacs-error-list-current-project-only
+            lsp-treemacs--current-workspaces)
        (->> lsp-treemacs--current-workspaces
             (-map #'lsp-workspace-folders)
             (-flatten)

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -109,6 +109,12 @@
   "Severity level for `lsp-treemacs-error-list-mode'. 1 (highest) to 3 (lowest)"
   :type 'number)
 
+(defcustom lsp-treemacs-error-list-current-project-only t
+  "List the error list of the current project only if available.
+Fallback to list all workspaces if no project root is found."
+  :type 'boolean
+  :group 'lsp-treemacs)
+
 (defun lsp-treemacs--open-file-in-mru (file)
   (select-window (get-mru-window (selected-frame) nil :not-selected))
   (find-file file))
@@ -1202,35 +1208,48 @@ With prefix 2 show both."
                             count)))
        (seq-some #'identity)))
 
+(defun lsp-treemacs--build-error-list (folders)
+  (-keep
+   (lambda (folder)
+     (when-let ((diags (append (lsp-diagnostics-stats-for folder) ())))
+       (when (lsp-treemacs-errors--diags? diags)
+         (list :label (format
+                       (propertize "%s %s %s" 'face 'default)
+                       (f-filename folder)
+                       (->> diags
+                         (-map-indexed
+                          (lambda (index count)
+                            (when (and (not (zerop count))
+                                       (<= index lsp-treemacs-error-list-severity))
+                              (propertize
+                               (number-to-string count)
+                               'face (alist-get index lsp-treemacs-file-face-map)))))
+                         (-filter #'identity)
+                         (s-join "/"))
+                       (propertize (f-dirname folder)
+                                   'face 'lsp-lens-face))
+               :id folder
+               :icon 'root
+               :children (-partial #'lsp-treemacs-errors--list-files folder)
+               :ret-action (lambda (&rest _)
+                             (interactive)
+                             (lsp-treemacs--open-file-in-mru folder))))))
+   folders))
+
+
+(defvar lsp-treemacs--current-project-root nil)
+
 (defun lsp-treemacs-errors-list--refresh ()
   (lsp-treemacs-render
-   (->> (lsp-session)
-        (lsp-session-folders)
-        (-keep
-         (lambda (folder)
-           (when-let ((diags (append (lsp-diagnostics-stats-for folder) ())))
-             (when (lsp-treemacs-errors--diags? diags)
-               (list :label (format
-                             (propertize "%s %s %s" 'face 'default)
-                             (f-filename folder)
-                             (->> diags
-                                  (-map-indexed
-                                   (lambda (index count)
-                                     (when (and (not (zerop count))
-                                                (<= index lsp-treemacs-error-list-severity))
-                                       (propertize
-                                        (number-to-string count)
-                                        'face (alist-get index lsp-treemacs-file-face-map)))))
-                                  (-filter #'identity)
-                                  (s-join "/"))
-                             (propertize (f-dirname folder)
-                                         'face 'lsp-lens-face))
-                     :id folder
-                     :icon 'root
-                     :children (-partial #'lsp-treemacs-errors--list-files folder)
-                     :ret-action (lambda (&rest _)
-                                   (interactive)
-                                   (lsp-treemacs--open-file-in-mru folder))))))))
+   (if (and lsp-treemacs--current-project-root
+            lsp-treemacs-error-list-current-project-only)
+       (->> (lsp-session)
+            (lsp-session-folders)
+            (--filter (f-equal-p lsp-treemacs--current-project-root it))
+            (lsp-treemacs--build-error-list))
+     (->> (lsp-session)
+          (lsp-session-folders)
+          (lsp-treemacs--build-error-list)))
    "Errors List"
    nil
    lsp-treemacs-errors-buffer-name
@@ -1239,6 +1258,9 @@ With prefix 2 show both."
 ;;;###autoload
 (defun lsp-treemacs-errors-list ()
   (interactive)
+  (setq lsp-treemacs--current-project-root (-some-> (lsp-workspaces)
+                                                    cl-first
+                                                    (lsp--workspace-root)))
   (-if-let (buffer (get-buffer lsp-treemacs-errors-buffer-name))
       (progn
         (select-window (display-buffer-in-side-window buffer '((side . bottom))))

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1208,51 +1208,44 @@ With prefix 2 show both."
                             count)))
        (seq-some #'identity)))
 
-(defun lsp-treemacs--build-error-list (folders)
-  (-keep
-   (lambda (folder)
-     (when-let ((diags (append (lsp-diagnostics-stats-for folder) ())))
-       (when (lsp-treemacs-errors--diags? diags)
-         (list :label (format
-                       (propertize "%s %s %s" 'face 'default)
-                       (f-filename folder)
-                       (->> diags
-                         (-map-indexed
-                          (lambda (index count)
-                            (when (and (not (zerop count))
-                                       (<= index lsp-treemacs-error-list-severity))
-                              (propertize
-                               (number-to-string count)
-                               'face (alist-get index lsp-treemacs-file-face-map)))))
-                         (-filter #'identity)
-                         (s-join "/"))
-                       (propertize (f-dirname folder)
-                                   'face 'lsp-lens-face))
-               :id folder
-               :icon 'root
-               :children (-partial #'lsp-treemacs-errors--list-files folder)
-               :ret-action (lambda (&rest _)
-                             (interactive)
-                             (lsp-treemacs--open-file-in-mru folder))))))
-   folders))
+(defun lsp-treemacs--build-error-list (folder)
+  (when-let ((diags (append (lsp-diagnostics-stats-for folder) ())))
+    (when (lsp-treemacs-errors--diags? diags)
+      (list :label (format
+                    (propertize "%s %s %s" 'face 'default)
+                    (f-filename folder)
+                    (->> diags
+                      (-map-indexed
+                       (lambda (index count)
+                         (when (and (not (zerop count))
+                                    (<= index lsp-treemacs-error-list-severity))
+                           (propertize
+                            (number-to-string count)
+                            'face (alist-get index lsp-treemacs-file-face-map)))))
+                      (-filter #'identity)
+                      (s-join "/"))
+                    (propertize (f-dirname folder)
+                                'face 'lsp-lens-face))
+            :id folder
+            :icon 'root
+            :children (-partial #'lsp-treemacs-errors--list-files folder)
+            :ret-action (lambda (&rest _)
+                          (interactive)
+                          (lsp-treemacs--open-file-in-mru folder))))))
 
-
-(defvar lsp-treemacs--current-project-roots nil)
+(defvar lsp-treemacs--current-workspaces nil)
 
 (defun lsp-treemacs-errors-list--refresh ()
-  (message "->%s" lsp-treemacs--current-project-roots)
   (lsp-treemacs-render
-   (if (and lsp-treemacs--current-project-roots
-            lsp-treemacs-error-list-current-project-only)
-       (->> (lsp-session)
-            (lsp-session-folders)
-            (-filter (lambda (folder)
-                       (--any (f-equal-p it folder)
-                              lsp-treemacs--current-project-roots)))
-            (lsp-treemacs--build-error-list))
-     (->> (lsp-session)
-          (lsp-session-folders)
-          (lsp-treemacs--build-error-list)))
+   (if lsp-treemacs-error-list-current-project-only
+       (->> lsp-treemacs--current-workspaces
+            (-map #'lsp-workspace-folders)
+            (-flatten)
+            (-keep #'lsp-treemacs--build-error-list))
+     (->> lsp-treemacs--current-workspaces
+          (-map #'lsp-workspace-folders)
+          (-flatten)
+          (-keep #'lsp-treemacs--build-error-list)))
    "Errors List"
    nil
    lsp-treemacs-errors-buffer-name
@@ -1261,7 +1254,7 @@ With prefix 2 show both."
 ;;;###autoload
 (defun lsp-treemacs-errors-list ()
   (interactive)
-  (setq lsp-treemacs--current-project-roots (-map #'lsp--workspace-root (lsp-workspaces)))
+  (setq lsp-treemacs--current-workspaces (lsp-workspaces))
   (-if-let (buffer (get-buffer lsp-treemacs-errors-buffer-name))
       (progn
         (select-window (display-buffer-in-side-window buffer '((side . bottom))))

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -109,7 +109,7 @@
   "Severity level for `lsp-treemacs-error-list-mode'. 1 (highest) to 3 (lowest)"
   :type 'number)
 
-(defcustom lsp-treemacs-error-list-current-project-only t
+(defcustom lsp-treemacs-error-list-current-project-only nil
   "List the error list of the current project only if available.
 Fallback to list all workspaces if no project root is found."
   :type 'boolean

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -1242,9 +1242,8 @@ With prefix 2 show both."
             (-map #'lsp-workspace-folders)
             (-flatten)
             (-keep #'lsp-treemacs--build-error-list))
-     (->> lsp-treemacs--current-workspaces
-          (-map #'lsp-workspace-folders)
-          (-flatten)
+     (->> (lsp-session)
+          (lsp-session-folders)
           (-keep #'lsp-treemacs--build-error-list)))
    "Errors List"
    nil


### PR DESCRIPTION
With this, if user is in an LSP managed buffer, `lsp-treemacs-error-list` will show only the current project errors instead of all available workspaces:
![image](https://user-images.githubusercontent.com/7820865/113795573-a3a3c280-9723-11eb-8d9a-210b29026d7f.png)

But if user is not in a LSP managed buffer we keep showing all workspaces errors:
![image](https://user-images.githubusercontent.com/7820865/113795606-aef6ee00-9723-11eb-90c2-729582d2c577.png)

This behavior can be disabled with `lsp-treemacs-error-list-current-project-only`, but IMO this is the best UX for community