### PR TITLE
Require f in lsp-treemacs-themes

### DIFF
--- a/lsp-treemacs-themes.el
+++ b/lsp-treemacs-themes.el
@@ -23,6 +23,7 @@
 ;;
 ;;; Code:
 
+(require 'f)
 (require 'treemacs)
 (require 'treemacs-themes)
 


### PR DESCRIPTION
It was already required in lsp-treemacs, but lsp-treemacs-themes
does not require that either.