### PR TITLE
Give all minor modes docstrings

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -582,7 +582,7 @@ will be rendered an empty line between them."
     m)
   "Keymap for `lsp-treemacs-deps-list-mode'.")
 
-(define-minor-mode lsp-treemacs-deps-list-mode ""
+(define-minor-mode lsp-treemacs-deps-list-mode "LSP Treemacs mode for listing dependencies."
   :keymap lsp-treemacs-deps-list-mode-map
   :group 'lsp-treemacs)
 
@@ -1315,7 +1315,7 @@ With prefix 2 show both."
     m)
   "Keymap for `lsp-treemacs-error-list-mode'.")
 
-(define-minor-mode lsp-treemacs-error-list-mode ""
+(define-minor-mode lsp-treemacs-error-list-mode "LSP Treemacs mode for listing errors."
   :keymap lsp-treemacs-error-list-mode-map
   :group 'lsp-treemacs)
 


### PR DESCRIPTION
Presently, on bleeding edge Emacs, `define-minor-mode` with an empty docstring makes the mode impossible to load as `""` is coerced to `nil` and subsequently `insert`ed, which is not kosher. The options as they stand are either a non-empty string (as I've done in this patch) or `nil`, which results in the fallback value of `Toggle <mode> on or off`. I'm not picky either way. I also sent a bug report to the Emacs list [here](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=55216) so this edge case will hopefully be covered (or explicitly disallowed) in the future.