### PR TITLE
Fix emacs native compilation warning 

### DIFF
--- a/Eask
+++ b/Eask
@@ -9,6 +9,9 @@
 (source "gnu")
 (source "melpa")
 
+(website-url "https://github.com/emacs-lsp/lsp-treemacs")
+(keywords "languages")
+
 (depends-on "emacs" "26.1")
 (depends-on "dash")
 (depends-on "f")

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -650,7 +650,8 @@ will be rendered an empty line between them."
 
 ;;;###autoload
 (define-minor-mode lsp-treemacs-sync-mode
-  "Global minor mode for synchronizing lsp-mode workspace folders and treemacs projects."
+  "Global minor mode for synchronizing lsp-mode workspace folders
+and treemacs projects."
   :init-value nil
   :group 'lsp-treemacs
   :global t
@@ -981,7 +982,8 @@ depending on if a custom mode line is detected."
 ;;;###autoload
 (defun lsp-treemacs-references (arg)
   "Show the references for the symbol at point.
-With a prefix argument, select the new window and expand the tree of references automatically."
+With a prefix argument, select the new window and expand the tree
+of references automatically."
   (interactive "P")
   (lsp-treemacs--do-search "textDocument/references"
                            `(:context (:includeDeclaration t) ,@(lsp--text-document-position-params))
@@ -991,7 +993,8 @@ With a prefix argument, select the new window and expand the tree of references 
 ;;;###autoload
 (defun lsp-treemacs-implementations (arg)
   "Show the implementations for the symbol at point.
-With a prefix argument, select the new window expand the tree of implementations automatically."
+With a prefix argument, select the new window expand the tree of
+implementations automatically."
   (interactive "P")
   (lsp-treemacs--do-search "textDocument/implementation"
                            (lsp--text-document-position-params)


### PR DESCRIPTION
To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.

```
 ■  Warning (comp): lsp-treemacs.el:652:2: Warning: docstring wider than
80 characters
 ■  Warning (comp): lsp-treemacs.el:982:2: Warning: docstring wider than
80 characters
 ■  Warning (comp): lsp-treemacs.el:992:2: Warning: docstring wider than
80 characters
```

Also fixes some eask specific warnings:
```
Unmatched website URL 
’[https://github.com/emacs-lsp/lsp-treemacs’](https://github.com/emacs-lsp/lsp-treemacs%E2%80%99); 
add (website-url "https://github.com/emacs-lsp/lsp-treemacs") to Eask-file

Unmatched keyword ’languages’; add (keywords ... "languages") to
Eask-file or consider removing it
```

There are also other emacs 29 warnings present but those need to be fixed in treemacs.