### PR TITLE
custom variables for expand depth

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -124,22 +124,22 @@ Fallback to list all workspaces if no project root is found."
   :type 'boolean
   :group 'lsp-treemacs)
 
-(defcustom lsp-treemacs-error-list-expand-depth 3
+(defcustom lsp-treemacs-error-list-expand-depth nil
   "Automatic expansion depth for `lsp-treemacs-error-list'"
   :type 'number
   :group 'lsp-treemacs)
 
-(defcustom lsp-treemacs-call-hierarchy-expand-depth 2
+(defcustom lsp-treemacs-call-hierarchy-expand-depth nil
   "Automatic expansion depth for `lsp-treemacs-call-hierarchy'"
   :type 'number
   :group 'lsp-treemacs)
 
-(defcustom lsp-treemacs-type-hierarchy-expand-depth 3
+(defcustom lsp-treemacs-type-hierarchy-expand-depth nil
   "Automatic expansion depth for `lsp-treemacs-type-hierarchy'"
   :type 'number
   :group 'lsp-treemacs)
 
-(defcustom lsp-treemacs-java-deps-list-expand-depth 2
+(defcustom lsp-treemacs-java-deps-list-expand-depth nil
   "Automatic expansion depth for `lsp-treemacs-java-deps-list'"
   :type 'number
   :group 'lsp-treemacs)

--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -124,6 +124,26 @@ Fallback to list all workspaces if no project root is found."
   :type 'boolean
   :group 'lsp-treemacs)
 
+(defcustom lsp-treemacs-error-list-expand-depth 3
+  "Automatic expansion depth for `lsp-treemacs-error-list'"
+  :type 'number
+  :group 'lsp-treemacs)
+
+(defcustom lsp-treemacs-call-hierarchy-expand-depth 2
+  "Automatic expansion depth for `lsp-treemacs-call-hierarchy'"
+  :type 'number
+  :group 'lsp-treemacs)
+
+(defcustom lsp-treemacs-type-hierarchy-expand-depth 3
+  "Automatic expansion depth for `lsp-treemacs-type-hierarchy'"
+  :type 'number
+  :group 'lsp-treemacs)
+
+(defcustom lsp-treemacs-java-deps-list-expand-depth 2
+  "Automatic expansion depth for `lsp-treemacs-java-deps-list'"
+  :type 'number
+  :group 'lsp-treemacs)
+
 (defun lsp-treemacs--open-file-in-mru (file)
   (select-window (get-mru-window (selected-frame) nil :not-selected))
   (find-file file))
@@ -482,7 +502,7 @@ will be rendered an empty line between them."
    (display-buffer-in-side-window
     (lsp-treemacs-render
      (-map 'lsp-treemacs-deps--process-dep (lsp-treemacs-deps--root-folders))
-     "*Java Deps*" nil)
+     "*Java Deps*" lsp-treemacs-java-deps-list-expand-depth)
     lsp-treemacs-deps-position-params)))
 
 (defun lsp-treemacs--deps-find-children-for-key (node key)
@@ -823,7 +843,7 @@ With a prefix argument, show the outgoing call hierarchy."
         (lsp-request "textDocument/prepareCallHierarchy"
                      (lsp--text-document-position-params)))
        (concat (if outgoing "Outgoing" "Incoming") " Call Hierarchy")
-       nil "*Call Hierarchy*" nil t) nil))))
+       lsp-treemacs-call-hierarchy-expand-depth "*Call Hierarchy*" nil t) nil))))
 
 
 
@@ -894,7 +914,7 @@ With prefix 2 show both."
                    ((eq lsp-treemacs--hierarchy-super direction) "Super")
                    ((eq lsp-treemacs--hierarchy-both direction) "Sub/Super"))
                   " Type Hierarchy")
-          nil
+          lsp-treemacs-type-hierarchy-expand-depth
           "*lsp-treemacs-call-hierarchy*"))
       (user-error "No class under point."))
     (setq lsp--buffer-workspaces workspaces)))
@@ -1029,7 +1049,7 @@ With prefix 2 show both."
           (lsp-session-folders)
           (-keep #'lsp-treemacs--build-error-list)))
    "Errors List"
-   nil
+   lsp-treemacs-error-list-expand-depth
    lsp-treemacs-errors-buffer-name
    `(["Cycle Severity" lsp-treemacs-cycle-severity])))
 


### PR DESCRIPTION
Adds the following custom variables for setting expand depth for various lists:
- lsp-treemacs-error-list-expand-depth
- lsp-treemacs-call-hierarchy-expand-depth
- lsp-treemacs-type-hierarchy-expand-depth
- lsp-treemacs-java-deps-list-expand-depth

Issue https://github.com/emacs-lsp/lsp-treemacs/issues/147