### PR TITLE
tests(test.yml): Setup node is no longer required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.1
-          - 26.2
           - 26.3
-          - 27.1
           - 27.2
-          - 28.1
+          - 28.2
           - snapshot
 
     steps:
@@ -24,10 +21,6 @@ jobs:
       - uses: jcs090218/setup-emacs@master
         with:
           version: ${{ matrix.emacs-version }}
-
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '16'
 
       - uses: emacs-eask/setup-eask@master
         with:


### PR DESCRIPTION
This is no longer needed for [setup-eask](https://github.com/emacs-eask/setup-eask).