### PR TITLE
join multiple lines of an error description into one line

### DIFF
--- a/lsp-treemacs.el
+++ b/lsp-treemacs.el
@@ -941,7 +941,7 @@ With prefix 2 show both."
                                         (propertize (format "[%s]" source?)
                                                     'face 'shadow)
                                       "")
-                                    message
+                                    (string-join (mapcar #'string-trim (string-lines message)) ", ")
                                     (propertize (format "(%s:%s)" line character)
                                                 'face 'lsp-details-face))
                      :icon-literal (lsp-treemacs--diagnostic-icon severity?)


### PR DESCRIPTION
Hi,

This PR makes the display of a multiple-line error message more readable by joining these lines into a single line:

Current behavior:
![lsp-treemacs-before](https://github.com/emacs-lsp/lsp-treemacs/assets/193967/1f6c2997-aba9-4dab-be13-86666022831d)

After applying this PR:
![lsp-treemacs-after](https://github.com/emacs-lsp/lsp-treemacs/assets/193967/d23d6484-b2f6-4b37-8815-f962116ecd96)

Please consider merging it.
Thanks!